### PR TITLE
fix: encode SEP14 command identifiers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.40.7
+    rev: v1.42.1
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.6
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* chore: refresh development tooling.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* chore: refresh development tooling.
+* Encode SEPM command identifiers before placing them in get-status request paths. [PSAAS-32518]

--- a/sep14_connector.py
+++ b/sep14_connector.py
@@ -688,7 +688,9 @@ class Sep14Connector(BaseConnector):
         endpoint_status_details = list()
         command_id = param["id"]
 
-        status_data = self._fetch_items_paginated(f"{consts.SEP_GET_STATUS_ENDPOINT}/{requests.compat.quote(command_id)}", action_result)
+        status_data = self._fetch_items_paginated(
+            f"{consts.SEP_GET_STATUS_ENDPOINT}/{requests.compat.quote(command_id, safe='')}", action_result
+        )
         if status_data is None:
             return action_result.get_status()
 


### PR DESCRIPTION
### Bug Fixes

- Encode get-status command identifiers as one SEPM request-path segment before issuing the authenticated request.

### Manual Documentation

- [x] I have verified that manual documentation is not required for this internal request-construction change.

### Other information

Tracking: ESPM-5228, PAPP-38301, PSAAS-32518.

PSAAS-33374 is already fixed by merged PR #24 and was closed as an Invalid duplicate.

The fix uses structural path-segment encoding with `requests.compat.quote(command_id, safe="")`; PSAAS-32518 cites the Python URL-quoting documentation as the source basis.

Validation: Python 3.13 standard-library path-encoding exercise, Python compilation, `git diff --check`, and full pre-commit with public PyPI after the internal mirror returned a zero-byte wheel during the refreshed-hook baseline.

All commits are signed. Written by Codex.

---
Please refer to the [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for questions.